### PR TITLE
Fix catalog swagger docs

### DIFF
--- a/src/CatalogApplication/Controllers/RatingsController.cs
+++ b/src/CatalogApplication/Controllers/RatingsController.cs
@@ -22,11 +22,6 @@ namespace ACMTTU.NoteSharing.Platform.CatalogApplication.Controllers
             _dbService = dbService;
         }
 
-        public Task<Rating> GetRatingValue(string nodeId)
-        {
-            throw new NotImplementedException();
-        }
-
         /// <summary>
         /// Gets the rating of a specific note.
         /// </summary>

--- a/src/CatalogApplication/Controllers/TagController.cs
+++ b/src/CatalogApplication/Controllers/TagController.cs
@@ -48,17 +48,6 @@ namespace ACMTTU.NoteSharing.Platform.CatalogApplication.Controllers
         }
 
         /// <summary>
-        /// Retrieve a list of tags by noteId.
-        /// </summary>
-        /// <param name="noteId">The note ID</param>
-        /// <returns>An array containing a value determined by the parameter</returns>
-        [HttpGet("{noteId}")]
-        public async Task<List<Tag>> GetTagsByNote(string noteId)
-        {
-            return await GetTags($"SELECT * FROM c WHERE c.noteId={noteId}");
-        }
-
-        /// <summary>
         /// Gets tags by noteId and userId
         /// </summary>
         /// <param name="noteId">The noteId to look for the tag</param>


### PR DESCRIPTION
Remove unnecessary methods that were causing Swagger to not work due to conflicting API signatures.